### PR TITLE
Agregar panel de gestión de usuarios (solo admin)

### DIFF
--- a/controllers/UserController.php
+++ b/controllers/UserController.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * CONTROLADOR DE USUARIOS
+ * Gestión de usuarios (solo para administradores)
+ */
+
+require_once 'models/User.php';
+require_once 'config/config.php';
+
+class UserController {
+    private $userModel;
+
+    public function __construct() {
+        $this->userModel = new User();
+    }
+
+    /**
+     * Listar todos los usuarios
+     */
+    public function index() {
+        // Solo admin puede acceder
+        requiereAdmin();
+
+        $titulo = 'Gestión de Usuarios - ' . APP_NAME;
+        $usuarios = $this->userModel->obtenerTodos(false); // Incluir inactivos
+        $flash = getFlashMessage();
+
+        // Cargar vista
+        ob_start();
+        include 'views/usuarios/index.php';
+        $contenido = ob_get_clean();
+        include 'views/layouts/master.php';
+    }
+
+    /**
+     * Mostrar formulario de creación
+     */
+    public function crear() {
+        // Solo admin puede acceder
+        requiereAdmin();
+
+        $titulo = 'Crear Usuario - ' . APP_NAME;
+        $flash = getFlashMessage();
+
+        // Cargar vista
+        ob_start();
+        include 'views/usuarios/formulario.php';
+        $contenido = ob_get_clean();
+        include 'views/layouts/master.php';
+    }
+
+    /**
+     * Guardar nuevo usuario
+     */
+    public function guardar() {
+        // Solo admin puede acceder
+        requiereAdmin();
+
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            redirect('usuarios', 'Método no permitido', 'error');
+        }
+
+        // Validar CSRF
+        if (!isset($_POST['csrf_token']) || !validateCSRFToken($_POST['csrf_token'])) {
+            redirect('usuarios', 'Token de seguridad inválido', 'error');
+        }
+
+        // Obtener datos del formulario
+        $datos = [
+            'nombre' => sanitize($_POST['nombre'] ?? ''),
+            'email' => sanitize($_POST['email'] ?? ''),
+            'password' => $_POST['password'] ?? '',
+            'password_confirmacion' => $_POST['password_confirmacion'] ?? '',
+            'rol' => sanitize($_POST['rol'] ?? 'vendedor')
+        ];
+
+        // Validar datos
+        $errores = $this->userModel->validar($datos);
+
+        if (!empty($errores)) {
+            $_SESSION['errores'] = $errores;
+            $_SESSION['datos_formulario'] = $datos;
+            redirect('usuarios/crear', null, 'error');
+        }
+
+        // Crear usuario
+        $nuevoId = $this->userModel->crear($datos);
+
+        if ($nuevoId) {
+            redirect('usuarios', 'Usuario creado exitosamente', 'success');
+        } else {
+            redirect('usuarios/crear', 'Error al crear el usuario', 'error');
+        }
+    }
+
+    /**
+     * Mostrar formulario de edición
+     */
+    public function editar($id) {
+        // Solo admin puede acceder
+        requiereAdmin();
+
+        $usuario = $this->userModel->obtenerPorId($id);
+
+        if (!$usuario) {
+            redirect('usuarios', 'Usuario no encontrado', 'error');
+        }
+
+        $titulo = 'Editar Usuario - ' . APP_NAME;
+        $flash = getFlashMessage();
+        $errores = $_SESSION['errores'] ?? [];
+        unset($_SESSION['errores']);
+
+        // Cargar vista
+        ob_start();
+        include 'views/usuarios/formulario.php';
+        $contenido = ob_get_clean();
+        include 'views/layouts/master.php';
+    }
+
+    /**
+     * Actualizar usuario existente
+     */
+    public function actualizar($id) {
+        // Solo admin puede acceder
+        requiereAdmin();
+
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            redirect('usuarios', 'Método no permitido', 'error');
+        }
+
+        // Validar CSRF
+        if (!isset($_POST['csrf_token']) || !validateCSRFToken($_POST['csrf_token'])) {
+            redirect('usuarios', 'Token de seguridad inválido', 'error');
+        }
+
+        // Verificar que el usuario existe
+        $usuarioExistente = $this->userModel->obtenerPorId($id);
+        if (!$usuarioExistente) {
+            redirect('usuarios', 'Usuario no encontrado', 'error');
+        }
+
+        // Obtener datos del formulario
+        $datos = [
+            'nombre' => sanitize($_POST['nombre'] ?? ''),
+            'email' => sanitize($_POST['email'] ?? ''),
+            'password' => $_POST['password'] ?? '',
+            'password_confirmacion' => $_POST['password_confirmacion'] ?? '',
+            'rol' => sanitize($_POST['rol'] ?? 'vendedor')
+        ];
+
+        // Validar datos
+        $errores = $this->userModel->validar($datos, $id);
+
+        if (!empty($errores)) {
+            $_SESSION['errores'] = $errores;
+            redirect('usuarios/editar/' . $id, null, 'error');
+        }
+
+        // Actualizar usuario
+        $resultado = $this->userModel->actualizar($id, $datos);
+
+        if ($resultado) {
+            redirect('usuarios', 'Usuario actualizado exitosamente', 'success');
+        } else {
+            redirect('usuarios/editar/' . $id, 'Error al actualizar el usuario', 'error');
+        }
+    }
+
+    /**
+     * Desactivar usuario (soft delete)
+     */
+    public function desactivar($id) {
+        // Solo admin puede acceder
+        requiereAdmin();
+
+        // No permitir desactivar el propio usuario
+        $usuarioActual = usuarioActual();
+        if ($usuarioActual['id'] == $id) {
+            redirect('usuarios', 'No puedes desactivar tu propio usuario', 'error');
+        }
+
+        $resultado = $this->userModel->desactivar($id);
+
+        if ($resultado) {
+            redirect('usuarios', 'Usuario desactivado exitosamente', 'success');
+        } else {
+            redirect('usuarios', 'Error al desactivar el usuario', 'error');
+        }
+    }
+
+    /**
+     * Activar usuario
+     */
+    public function activar($id) {
+        // Solo admin puede acceder
+        requiereAdmin();
+
+        $resultado = $this->userModel->activar($id);
+
+        if ($resultado) {
+            redirect('usuarios', 'Usuario activado exitosamente', 'success');
+        } else {
+            redirect('usuarios', 'Error al activar el usuario', 'error');
+        }
+    }
+
+    /**
+     * Cambiar contraseña de usuario
+     */
+    public function cambiarPassword($id) {
+        // Solo admin puede acceder
+        requiereAdmin();
+
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            redirect('usuarios', 'Método no permitido', 'error');
+        }
+
+        // Validar CSRF
+        if (!isset($_POST['csrf_token']) || !validateCSRFToken($_POST['csrf_token'])) {
+            redirect('usuarios', 'Token de seguridad inválido', 'error');
+        }
+
+        $passwordNuevo = $_POST['password_nuevo'] ?? '';
+        $passwordConfirmacion = $_POST['password_confirmacion'] ?? '';
+
+        // Validar
+        if (empty($passwordNuevo)) {
+            redirect('usuarios/editar/' . $id, 'La contraseña es requerida', 'error');
+        }
+
+        if (strlen($passwordNuevo) < 6) {
+            redirect('usuarios/editar/' . $id, 'La contraseña debe tener al menos 6 caracteres', 'error');
+        }
+
+        if ($passwordNuevo !== $passwordConfirmacion) {
+            redirect('usuarios/editar/' . $id, 'Las contraseñas no coinciden', 'error');
+        }
+
+        // Cambiar password
+        $resultado = $this->userModel->cambiarPassword($id, $passwordNuevo);
+
+        if ($resultado) {
+            redirect('usuarios', 'Contraseña actualizada exitosamente', 'success');
+        } else {
+            redirect('usuarios/editar/' . $id, 'Error al cambiar la contraseña', 'error');
+        }
+    }
+}
+?>

--- a/index.php
+++ b/index.php
@@ -34,11 +34,6 @@ switch ($path) {
         $controller->logout();
         break;
 
-    case 'registro':
-        $controller = new AuthController();
-        $controller->registro();
-        break;
-
     // Rutas protegidas (requieren autenticación)
     case '':
     case 'dashboard':
@@ -96,7 +91,57 @@ switch ($path) {
         $controller = new ProductoController();
         $controller->buscar();
         break;
-        
+
+    // Rutas de gestión de usuarios (solo admin)
+    case 'usuarios':
+        requiereAdmin();
+        require_once 'controllers/UserController.php';
+        $controller = new UserController();
+        $controller->index();
+        break;
+
+    case 'usuarios/crear':
+        requiereAdmin();
+        require_once 'controllers/UserController.php';
+        $controller = new UserController();
+        $controller->crear();
+        break;
+
+    case 'usuarios/guardar':
+        requiereAdmin();
+        require_once 'controllers/UserController.php';
+        $controller = new UserController();
+        $controller->guardar();
+        break;
+
+    case (preg_match('/usuarios\/editar\/(\d+)/', $path, $matches) ? true : false):
+        requiereAdmin();
+        require_once 'controllers/UserController.php';
+        $controller = new UserController();
+        $controller->editar($matches[1]);
+        break;
+
+    case (preg_match('/usuarios\/actualizar\/(\d+)/', $path, $matches) ? true : false):
+        requiereAdmin();
+        require_once 'controllers/UserController.php';
+        $controller = new UserController();
+        $controller->actualizar($matches[1]);
+        break;
+
+    case (preg_match('/usuarios\/desactivar\/(\d+)/', $path, $matches) ? true : false):
+        requiereAdmin();
+        require_once 'controllers/UserController.php';
+        $controller = new UserController();
+        $controller->desactivar($matches[1]);
+        break;
+
+    case (preg_match('/usuarios\/activar\/(\d+)/', $path, $matches) ? true : false):
+        requiereAdmin();
+        require_once 'controllers/UserController.php';
+        $controller = new UserController();
+        $controller->activar($matches[1]);
+        break;
+
     default:
         http_response_code(404);
         include 'views/404.php';

--- a/views/layouts/master.php
+++ b/views/layouts/master.php
@@ -100,6 +100,19 @@
                             <i class="bi bi-plus-circle"></i> Nuevo Producto
                         </a>
                     </li>
+
+                    <?php
+                    // Mostrar opción de usuarios solo para admins
+                    $usuarioActual = usuarioActual();
+                    if ($usuarioActual && $usuarioActual['rol'] === 'admin'):
+                    ?>
+                        <hr class="text-white-50 my-2">
+                        <li class="nav-item">
+                            <a class="nav-link <?= (strpos($_SERVER['REQUEST_URI'], 'usuarios') !== false) ? 'active' : '' ?>" href="<?= APP_URL ?>/usuarios">
+                                <i class="bi bi-people"></i> Usuarios
+                            </a>
+                        </li>
+                    <?php endif; ?>
                 </ul>
 
                 <hr class="text-white-50 my-4">
@@ -145,6 +158,12 @@
                         $rutaActual = $_SERVER['REQUEST_URI'];
                         if (strpos($rutaActual, 'dashboard') !== false || $rutaActual === '/' || $rutaActual === '') {
                             echo '<i class="bi bi-speedometer2"></i> Dashboard';
+                        } elseif (strpos($rutaActual, 'usuarios/crear') !== false) {
+                            echo '<i class="bi bi-person-plus"></i> Crear Usuario';
+                        } elseif (strpos($rutaActual, 'usuarios/editar') !== false) {
+                            echo '<i class="bi bi-pencil-square"></i> Editar Usuario';
+                        } elseif (strpos($rutaActual, 'usuarios') !== false) {
+                            echo '<i class="bi bi-people"></i> Usuarios';
                         } elseif (strpos($rutaActual, 'productos/crear') !== false) {
                             echo '<i class="bi bi-plus-circle"></i> Nuevo Producto';
                         } elseif (strpos($rutaActual, 'productos/editar') !== false) {

--- a/views/usuarios/formulario.php
+++ b/views/usuarios/formulario.php
@@ -1,0 +1,165 @@
+<?php
+$esEdicion = isset($usuario);
+$datosFormulario = $_SESSION['datos_formulario'] ?? [];
+unset($_SESSION['datos_formulario']);
+?>
+
+<div class="row justify-content-center">
+    <div class="col-md-8">
+        <div class="card">
+            <div class="card-header bg-primary text-white">
+                <h5 class="mb-0">
+                    <i class="bi bi-<?= $esEdicion ? 'pencil-square' : 'person-plus' ?>"></i>
+                    <?= $esEdicion ? 'Editar Usuario' : 'Crear Nuevo Usuario' ?>
+                </h5>
+            </div>
+            <div class="card-body">
+                <form method="POST" action="<?= APP_URL ?>/usuarios/<?= $esEdicion ? 'actualizar/' . $usuario['id'] : 'guardar' ?>">
+                    <!-- CSRF Token -->
+                    <input type="hidden" name="csrf_token" value="<?= generateCSRFToken() ?>">
+
+                    <!-- Nombre -->
+                    <div class="mb-3">
+                        <label for="nombre" class="form-label">
+                            <i class="bi bi-person"></i> Nombre Completo <span class="text-danger">*</span>
+                        </label>
+                        <input type="text"
+                               class="form-control"
+                               id="nombre"
+                               name="nombre"
+                               value="<?= htmlspecialchars($usuario['nombre'] ?? $datosFormulario['nombre'] ?? '') ?>"
+                               required
+                               autofocus>
+                    </div>
+
+                    <!-- Email -->
+                    <div class="mb-3">
+                        <label for="email" class="form-label">
+                            <i class="bi bi-envelope"></i> Email <span class="text-danger">*</span>
+                        </label>
+                        <input type="email"
+                               class="form-control"
+                               id="email"
+                               name="email"
+                               value="<?= htmlspecialchars($usuario['email'] ?? $datosFormulario['email'] ?? '') ?>"
+                               required>
+                        <small class="text-muted">El usuario usará este email para iniciar sesión</small>
+                    </div>
+
+                    <!-- Rol -->
+                    <div class="mb-3">
+                        <label for="rol" class="form-label">
+                            <i class="bi bi-shield-check"></i> Rol <span class="text-danger">*</span>
+                        </label>
+                        <select class="form-select" id="rol" name="rol" required>
+                            <?php
+                            $rolActual = $usuario['rol'] ?? $datosFormulario['rol'] ?? 'vendedor';
+                            $roles = [
+                                'admin' => 'Administrador (acceso total)',
+                                'supervisor' => 'Supervisor (visualización y reportes)',
+                                'vendedor' => 'Vendedor (gestión de productos)'
+                            ];
+                            ?>
+                            <?php foreach ($roles as $valor => $descripcion): ?>
+                                <option value="<?= $valor ?>" <?= $rolActual === $valor ? 'selected' : '' ?>>
+                                    <?= $descripcion ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+
+                    <hr>
+
+                    <!-- Contraseña -->
+                    <div class="mb-3">
+                        <label for="password" class="form-label">
+                            <i class="bi bi-lock"></i> Contraseña
+                            <?php if (!$esEdicion): ?>
+                                <span class="text-danger">*</span>
+                            <?php else: ?>
+                                <small class="text-muted">(dejar en blanco para mantener la actual)</small>
+                            <?php endif; ?>
+                        </label>
+                        <input type="password"
+                               class="form-control"
+                               id="password"
+                               name="password"
+                               minlength="6"
+                               <?= !$esEdicion ? 'required' : '' ?>>
+                        <small class="text-muted">Mínimo 6 caracteres</small>
+                    </div>
+
+                    <!-- Confirmar Contraseña -->
+                    <div class="mb-3">
+                        <label for="password_confirmacion" class="form-label">
+                            <i class="bi bi-lock-fill"></i> Confirmar Contraseña
+                            <?php if (!$esEdicion): ?>
+                                <span class="text-danger">*</span>
+                            <?php endif; ?>
+                        </label>
+                        <input type="password"
+                               class="form-control"
+                               id="password_confirmacion"
+                               name="password_confirmacion"
+                               minlength="6"
+                               <?= !$esEdicion ? 'required' : '' ?>>
+                    </div>
+
+                    <!-- Botones -->
+                    <div class="d-flex justify-content-between mt-4">
+                        <a href="<?= APP_URL ?>/usuarios" class="btn btn-secondary">
+                            <i class="bi bi-arrow-left"></i> Cancelar
+                        </a>
+                        <button type="submit" class="btn btn-primary">
+                            <i class="bi bi-<?= $esEdicion ? 'save' : 'plus-circle' ?>"></i>
+                            <?= $esEdicion ? 'Actualizar Usuario' : 'Crear Usuario' ?>
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        <?php if ($esEdicion): ?>
+            <!-- Card de información adicional -->
+            <div class="card mt-3">
+                <div class="card-body">
+                    <h6 class="card-title">
+                        <i class="bi bi-info-circle"></i> Información del Usuario
+                    </h6>
+                    <ul class="list-unstyled mb-0">
+                        <li><strong>ID:</strong> <?= $usuario['id'] ?></li>
+                        <li><strong>Registrado:</strong> <?= date('d/m/Y H:i', strtotime($usuario['fecha_creacion'])) ?></li>
+                        <?php if ($usuario['ultimo_acceso']): ?>
+                            <li><strong>Último acceso:</strong> <?= date('d/m/Y H:i', strtotime($usuario['ultimo_acceso'])) ?></li>
+                        <?php endif; ?>
+                        <li>
+                            <strong>Estado:</strong>
+                            <?php if ($usuario['activo']): ?>
+                                <span class="badge bg-success">Activo</span>
+                            <?php else: ?>
+                                <span class="badge bg-secondary">Inactivo</span>
+                            <?php endif; ?>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        <?php endif; ?>
+    </div>
+</div>
+
+<script>
+// Validar que las contraseñas coincidan
+document.querySelector('form').addEventListener('submit', function(e) {
+    const password = document.getElementById('password').value;
+    const confirmacion = document.getElementById('password_confirmacion').value;
+
+    // Solo validar si se ingresó un password
+    if (password || confirmacion) {
+        if (password !== confirmacion) {
+            e.preventDefault();
+            alert('Las contraseñas no coinciden');
+            document.getElementById('password_confirmacion').focus();
+        }
+    }
+});
+</script>

--- a/views/usuarios/index.php
+++ b/views/usuarios/index.php
@@ -1,0 +1,148 @@
+<div class="row mb-4">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-body">
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <h5 class="card-title mb-0">
+                        <i class="bi bi-people"></i> Lista de Usuarios
+                    </h5>
+                    <a href="<?= APP_URL ?>/usuarios/crear" class="btn btn-primary">
+                        <i class="bi bi-person-plus"></i> Nuevo Usuario
+                    </a>
+                </div>
+
+                <div class="table-responsive">
+                    <table class="table table-hover">
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Nombre</th>
+                                <th>Email</th>
+                                <th>Rol</th>
+                                <th>Estado</th>
+                                <th>Último Acceso</th>
+                                <th>Acciones</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php if (empty($usuarios)): ?>
+                                <tr>
+                                    <td colspan="7" class="text-center text-muted py-4">
+                                        <i class="bi bi-inbox" style="font-size: 3rem;"></i>
+                                        <p class="mt-2">No hay usuarios registrados</p>
+                                    </td>
+                                </tr>
+                            <?php else: ?>
+                                <?php foreach ($usuarios as $usuario): ?>
+                                    <tr>
+                                        <td><?= $usuario['id'] ?></td>
+                                        <td>
+                                            <i class="bi bi-person-circle"></i>
+                                            <?= htmlspecialchars($usuario['nombre']) ?>
+                                        </td>
+                                        <td><?= htmlspecialchars($usuario['email']) ?></td>
+                                        <td>
+                                            <?php
+                                            $badgeColor = [
+                                                'admin' => 'danger',
+                                                'supervisor' => 'warning',
+                                                'vendedor' => 'info'
+                                            ];
+                                            $color = $badgeColor[$usuario['rol']] ?? 'secondary';
+                                            ?>
+                                            <span class="badge bg-<?= $color ?>">
+                                                <i class="bi bi-shield-check"></i>
+                                                <?= ucfirst($usuario['rol']) ?>
+                                            </span>
+                                        </td>
+                                        <td>
+                                            <?php if ($usuario['activo']): ?>
+                                                <span class="badge bg-success">
+                                                    <i class="bi bi-check-circle"></i> Activo
+                                                </span>
+                                            <?php else: ?>
+                                                <span class="badge bg-secondary">
+                                                    <i class="bi bi-x-circle"></i> Inactivo
+                                                </span>
+                                            <?php endif; ?>
+                                        </td>
+                                        <td>
+                                            <?php if ($usuario['ultimo_acceso']): ?>
+                                                <small class="text-muted">
+                                                    <?= date('d/m/Y H:i', strtotime($usuario['ultimo_acceso'])) ?>
+                                                </small>
+                                            <?php else: ?>
+                                                <small class="text-muted">Nunca</small>
+                                            <?php endif; ?>
+                                        </td>
+                                        <td>
+                                            <div class="btn-group btn-group-sm" role="group">
+                                                <a href="<?= APP_URL ?>/usuarios/editar/<?= $usuario['id'] ?>"
+                                                   class="btn btn-outline-primary"
+                                                   title="Editar">
+                                                    <i class="bi bi-pencil"></i>
+                                                </a>
+
+                                                <?php if ($usuario['activo']): ?>
+                                                    <button type="button"
+                                                            class="btn btn-outline-warning"
+                                                            onclick="desactivarUsuario(<?= $usuario['id'] ?>, '<?= htmlspecialchars($usuario['nombre']) ?>')"
+                                                            title="Desactivar">
+                                                        <i class="bi bi-ban"></i>
+                                                    </button>
+                                                <?php else: ?>
+                                                    <button type="button"
+                                                            class="btn btn-outline-success"
+                                                            onclick="activarUsuario(<?= $usuario['id'] ?>, '<?= htmlspecialchars($usuario['nombre']) ?>')"
+                                                            title="Activar">
+                                                        <i class="bi bi-check-circle"></i>
+                                                    </button>
+                                                <?php endif; ?>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                <?php endforeach; ?>
+                            <?php endif; ?>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+function desactivarUsuario(id, nombre) {
+    if (confirm(`¿Estás seguro de que deseas desactivar al usuario "${nombre}"?\n\nEl usuario no podrá iniciar sesión hasta que lo actives nuevamente.`)) {
+        const form = document.createElement('form');
+        form.method = 'POST';
+        form.action = `<?= APP_URL ?>/usuarios/desactivar/${id}`;
+
+        const csrfToken = document.createElement('input');
+        csrfToken.type = 'hidden';
+        csrfToken.name = 'csrf_token';
+        csrfToken.value = '<?= generateCSRFToken() ?>';
+        form.appendChild(csrfToken);
+
+        document.body.appendChild(form);
+        form.submit();
+    }
+}
+
+function activarUsuario(id, nombre) {
+    if (confirm(`¿Deseas activar al usuario "${nombre}"?`)) {
+        const form = document.createElement('form');
+        form.method = 'POST';
+        form.action = `<?= APP_URL ?>/usuarios/activar/${id}`;
+
+        const csrfToken = document.createElement('input');
+        csrfToken.type = 'hidden';
+        csrfToken.name = 'csrf_token';
+        csrfToken.value = '<?= generateCSRFToken() ?>';
+        form.appendChild(csrfToken);
+
+        document.body.appendChild(form);
+        form.submit();
+    }
+}
+</script>


### PR DESCRIPTION
## Panel de Gestión de Usuarios

### Funcionalidades
- CRUD completo de usuarios (crear, editar, activar/desactivar)
- Panel exclusivo para usuarios con rol admin
- Asignación de roles (admin, supervisor, vendedor)
- Validación de contraseñas y confirmación
- Prevención de auto-desactivación
- Tracking de último acceso por usuario

### Seguridad
- Todas las rutas protegidas con requiereAdmin()
- CSRF tokens en formularios
- Validaciones de password (mínimo 6 caracteres)
- Sanitización de inputs
- Eliminación de ruta de registro público

### Cambios
- Nuevo UserController con CRUD completo
- Vistas de listado y formulario de usuarios
- Opción Usuarios en sidebar (solo visible para admin)
- Rutas protegidas solo para administradores
- Script create_admin_user.php mejorado

### Testing
✅ Probado exitosamente en dev.inventory.kyoshop.co
✅ Creación de usuarios funcionando
✅ Edición de usuarios funcionando
✅ Activar/desactivar usuarios funcionando
✅ Validaciones de permisos correctas