### PR TITLE
SECURITY: Bloquear acceso web a scripts administrativos

### DIFF
--- a/scripts/.htaccess
+++ b/scripts/.htaccess
@@ -1,0 +1,9 @@
+# Bloquear acceso web a scripts administrativos
+# Solo accesibles vía SSH/CLI
+
+Order deny,allow
+Deny from all
+
+<FilesMatch "\.(md|txt)$">
+    Allow from all
+</FilesMatch>

--- a/scripts/create_admin_user.php
+++ b/scripts/create_admin_user.php
@@ -7,7 +7,15 @@
  * Este script crea el usuario admin por defecto con credenciales:
  * Email: admin@kyoshop.co
  * Password: admin123
+ *
+ * SEGURIDAD: Solo ejecutable desde línea de comandos (CLI)
  */
+
+// PROTECCIÓN: Solo permitir ejecución desde CLI
+if (php_sapi_name() !== 'cli') {
+    http_response_code(403);
+    die('Acceso denegado. Este script solo puede ejecutarse desde línea de comandos.');
+}
 
 // Cargar configuración
 require_once __DIR__ . '/../config/database.php';


### PR DESCRIPTION
## 🚨 Fix de Seguridad Crítico

### Vulnerabilidad Identificada
Scripts administrativos eran accesibles vía navegador web en:
`https://inventory.kyoshop.co/scripts/create_admin_user.php`

### Riesgo
- Exposición de información sensible
- Posible ejecución no autorizada de scripts admin
- Revelación de estructura de base de datos

### Solución Implementada
1. **Protección PHP**: Verificación CLI-only en el script
   - Solo ejecutable vía SSH (`php scripts/...`)
   - Retorna 403 Forbidden si se accede vía web

2. **Protección Apache**: .htaccess en directorio scripts/
   - Bloquea todo acceso web a archivos PHP
   - Permite solo archivos de documentación (.md, .txt)

### Resultado
- ✅ Scripts solo ejecutables vía SSH/CLI
- ❌ Acceso web bloqueado (403 Forbidden)
- ✅ Sin impacto en funcionalidad normal del sitio

### Testing
✅ Verificado que bloquea acceso web
✅ Verificado que funciona vía SSH
✅ Sin conflictos con .htaccess principal

**PRIORIDAD: ALTA - Merge inmediato recomendado**