### PR TITLE
Fix: Mejorar contraste del botón limpiar filtros en dark mode

### DIFF
--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -92,13 +92,23 @@
     }
     
     .btn-outline-secondary {
-        color: var(--dark-text);
+        color: #212529 !important;
         border-color: var(--dark-border);
+        background-color: transparent;
     }
-    
+
+    .btn-outline-secondary .bi {
+        color: #212529 !important;
+    }
+
     .btn-outline-secondary:hover {
-        background-color: var(--dark-border);
-        color: var(--dark-text);
+        background-color: #212529 !important;
+        color: #ffffff !important;
+        border-color: #212529;
+    }
+
+    .btn-outline-secondary:hover .bi {
+        color: #ffffff !important;
     }
     
     /* Dark mode badges */


### PR DESCRIPTION
## Cambios

- Corregir contraste del botón "Limpiar filtros" en modo oscuro
- Estado normal: texto e icono negro sobre fondo transparente
- Estado hover: fondo negro con texto e icono blanco

Probado en desarrollo con dark mode activado.