### PR TITLE
Fix: Mejoras completas de contraste en dark mode y Windows

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -53,8 +53,8 @@
     border: 1px solid #ddd;
     padding: 0.75rem 1rem;
     transition: all 0.3s ease;
-    background-color: #ffffff;
-    color: #212529;
+    background-color: #ffffff !important;
+    color: #212529 !important;
 }
 
 .form-control:focus,

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -75,6 +75,12 @@
     opacity: 1;
 }
 
+/* Fix select options visibility in Windows */
+.form-select option {
+    background-color: #ffffff;
+    color: #212529;
+}
+
 /* Search and Filters */
 .input-group-text {
     background: white;

--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -79,6 +79,11 @@
         color: var(--dark-text-secondary);
     }
 
+    .form-select option {
+        background-color: #3a3a3a;
+        color: var(--dark-text);
+    }
+
     .form-label {
         color: var(--dark-text) !important;
     }

--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -70,8 +70,8 @@
     
     .form-control,
     .form-select {
-        background-color: #3a3a3a;
-        color: var(--dark-text);
+        background-color: #3a3a3a !important;
+        color: var(--dark-text) !important;
         border-color: var(--dark-border);
     }
     


### PR DESCRIPTION
## Cambios

### Contraste en Dark Mode
- Labels de formularios con texto blanco visible
- Botón "Limpiar filtros" con texto negro en estado normal
- Mensajes flash con mejor contraste (texto oscuro sobre fondo claro)

### Fix para Windows
- Opciones del select de categorías ahora visibles
- Texto seleccionado en select visible después de elegir
- Fondo blanco con texto negro en modo normal

Todos los cambios probados en desarrollo.