### PR TITLE
Agregar confirmación al editar producto

### DIFF
--- a/controllers/ProductoController.php
+++ b/controllers/ProductoController.php
@@ -195,7 +195,7 @@ class ProductoController {
         
         try {
             $this->producto->actualizar($id, $datos);
-            redirect('productos', 'Producto actualizado exitosamente');
+            redirect('productos', 'Producto actualizado exitosamente', 'success');
         } catch (Exception $e) {
             error_log("Error al actualizar producto: " . $e->getMessage());
             redirect("productos/editar/{$id}", 'Error al actualizar el producto', 'error');

--- a/views/productos/formulario.php
+++ b/views/productos/formulario.php
@@ -209,17 +209,25 @@
     document.querySelector('form').addEventListener('submit', function(e) {
         const precio = parseFloat(document.getElementById('precio').value);
         const stock = parseInt(document.getElementById('stock').value);
-        
+
         if (precio <= 0) {
             e.preventDefault();
             alert('El precio debe ser mayor a 0');
             return;
         }
-        
+
         if (stock < 0) {
             e.preventDefault();
             alert('El stock no puede ser negativo');
             return;
         }
+
+        // Confirmación al editar producto
+        <?php if ($accion !== 'crear'): ?>
+        if (!confirm('¿Estás seguro de que deseas actualizar este producto?')) {
+            e.preventDefault();
+            return;
+        }
+        <?php endif; ?>
     });
 </script>


### PR DESCRIPTION
## Cambios

- Agregar diálogo de confirmación antes de actualizar un producto
- Mensaje: "¿Estás seguro de que deseas actualizar este producto?"
- Solo aparece al editar, no al crear productos nuevos
- Mejorar visibilidad del mensaje de éxito al actualizar

Probado en desarrollo.