### PR TITLE
Fix: Corregir envío de campos talla y color en formulario

### DIFF
--- a/views/productos/formulario.php
+++ b/views/productos/formulario.php
@@ -113,7 +113,7 @@
                             <div class="row">
                                 <div class="col-md-6 mb-3">
                                     <label for="color" class="form-label">Color</label>
-                                    <select class="form-select" id="color_select" onchange="toggleColorOtro(this, 'color_otro_input')">
+                                    <select class="form-select" id="color_select" name="color" onchange="toggleColorOtro(this, 'color_otro_input')">
                                         <option value="">Seleccione un color</option>
                                         <optgroup label="Colores Básicos">
                                             <option value="Blanco" <?= ($datos_antiguos['color'] ?? '') === 'Blanco' ? 'selected' : '' ?>>Blanco</option>
@@ -150,7 +150,7 @@
 
                                 <div class="col-md-6 mb-3">
                                     <label for="talla" class="form-label">Talla</label>
-                                    <select class="form-select" id="talla_select" onchange="toggleTallaOtro(this, 'talla_otro_input')">
+                                    <select class="form-select" id="talla_select" name="talla" onchange="toggleTallaOtro(this, 'talla_otro_input')">
                                         <option value="">Seleccione una talla</option>
                                         <optgroup label="Tallas Letras">
                                             <option value="XS" <?= ($datos_antiguos['talla'] ?? '') === 'XS' ? 'selected' : '' ?>>XS</option>
@@ -214,7 +214,7 @@
                                     $colores_predefinidos = ['Blanco', 'Negro', 'Gris', 'Beige', 'Café', 'Rojo', 'Azul', 'Verde', 'Amarillo', 'Naranja', 'Rosa', 'Morado', 'Fucsia', 'Azul Marino', 'Vino Tinto', 'Verde Oliva', 'Turquesa', 'Dorado', 'Plateado', 'Multicolor'];
                                     $es_color_otro = !empty($color_actual) && !in_array($color_actual, $colores_predefinidos);
                                 ?>
-                                <select class="form-select" id="color_select_edit" onchange="toggleColorOtro(this, 'color_otro_input_edit')">
+                                <select class="form-select" id="color_select_edit" name="color" onchange="toggleColorOtro(this, 'color_otro_input_edit')">
                                     <option value="">Seleccione un color</option>
                                     <optgroup label="Colores Básicos">
                                         <option value="Blanco" <?= $color_actual === 'Blanco' ? 'selected' : '' ?>>Blanco</option>
@@ -257,7 +257,7 @@
                                     $tallas_predefinidas = ['XS', 'S', 'M', 'L', 'XL', 'XXL', '28', '30', '32', '34', '36', '38', '40', '42', '2', '4', '6', '8', '10', '12', '14', '16', 'Única'];
                                     $es_talla_otra = !empty($talla_actual) && !in_array($talla_actual, $tallas_predefinidas);
                                 ?>
-                                <select class="form-select" id="talla_select_edit" onchange="toggleTallaOtro(this, 'talla_otro_input_edit')">
+                                <select class="form-select" id="talla_select_edit" name="talla" onchange="toggleTallaOtro(this, 'talla_otro_input_edit')">
                                     <option value="">Seleccione una talla</option>
                                     <optgroup label="Tallas Letras">
                                         <option value="XS" <?= $talla_actual === 'XS' ? 'selected' : '' ?>>XS</option>
@@ -579,11 +579,13 @@
             inputOtro.style.display = 'block';
             inputOtro.required = true;
             selectElement.removeAttribute('name'); // Remover name del select
+            inputOtro.setAttribute('name', 'talla'); // Agregar name al input
         } else {
             inputOtro.style.display = 'none';
             inputOtro.required = false;
             inputOtro.value = '';
             selectElement.setAttribute('name', 'talla'); // Restaurar name al select
+            inputOtro.removeAttribute('name'); // Remover name del input
         }
     }
 
@@ -614,11 +616,13 @@
             inputOtro.style.display = 'block';
             inputOtro.required = true;
             selectElement.removeAttribute('name'); // Remover name del select
+            inputOtro.setAttribute('name', 'color'); // Agregar name al input
         } else {
             inputOtro.style.display = 'none';
             inputOtro.required = false;
             inputOtro.value = '';
             selectElement.setAttribute('name', 'color'); // Restaurar name al select
+            inputOtro.removeAttribute('name'); // Remover name del input
         }
     }
 


### PR DESCRIPTION
## Resumen

Corrige múltiples bugs críticos relacionados con PDO y parámetros SQL que impedían el funcionamiento correcto de filtros y búsquedas en el sistema.

### Problemas Identificados

**Bug #1: Campos talla y color no se guardaban**
- Los selectores `<select>` de talla y color **no tenían el atributo `name`**
- Al enviar formularios, estos valores no llegaban al servidor
- Productos se guardaban sin talla ni color en la base de datos

**Bug #2: Error PDO con LIMIT y OFFSET**
- `SQLSTATE[HY093]: Invalid parameter number` al usar filtros
- PDO no puede bindear LIMIT/OFFSET como parámetros string usando placeholders
- Afectaba paginación y listados en todos los modelos

**Bug #3: Error PDO con búsqueda de texto**
- `SQLSTATE[HY093]: Invalid parameter number` al buscar por nombre/código
- Se usaba el mismo placeholder `:busqueda` tres veces en la query
- PDO solo esperaba un parámetro, no tres reutilizaciones

### Soluciones Implementadas

#### Fix #1: Campos talla y color (commit 8691322)
✅ Agregado `name="talla"` a selectores de talla (creación y edición)
✅ Agregado `name="color"` a selectores de color (creación y edición)
✅ Corregidas funciones JavaScript `toggleTallaOtro()` y `toggleColorOtro()`:
   - Opción normal: `<select>` mantiene `name`
   - Opción "Otro": `<select>` pierde `name` y el `<input>` lo recibe

#### Fix #2: LIMIT y OFFSET (commit 8e30d70)
✅ Convertir parámetros a enteros: `$limite = (int)$limite;`
✅ Usar interpolación directa: `LIMIT {$limite} OFFSET {$offset}`
✅ Corregido en:
   - `Producto::obtenerTodos()`
   - `Producto::buscar()`
   - `HistorialMovimiento::obtenerHistorial()`
   - `HistorialMovimiento::obtenerUltimosMovimientos()`
   - `Combo::generarProductosAleatorios()`

#### Fix #3: Parámetros de búsqueda (commit 87edc86)
✅ Usar placeholders únicos: `:busqueda1`, `:busqueda2`, `:busqueda3`
✅ Bindear cada parámetro individualmente
✅ Corregido en `Producto::obtenerTodos()` y `Producto::contarTotal()`

### Archivos modificados
- `views/productos/formulario.php` - Fix campos talla/color
- `models/Producto.php` - Fix LIMIT/OFFSET y búsqueda
- `models/HistorialMovimiento.php` - Fix LIMIT/OFFSET
- `models/Combo.php` - Fix LIMIT/OFFSET

### Test Plan
- [x] Crear producto con talla del dropdown → ✅ Se guarda correctamente
- [x] Crear producto con color del dropdown → ✅ Se guarda correctamente
- [x] Crear producto con talla personalizada → ✅ Se guarda correctamente
- [x] Crear producto con color personalizado → ✅ Se guarda correctamente
- [x] Filtrar por categoría/tipo/ubicación → ✅ Funciona sin errores
- [x] Buscar por nombre de producto → ✅ Funciona sin errores
- [x] Buscar por código de producto → ✅ Funciona sin errores
- [x] Combinar búsqueda + filtros → ✅ Funciona sin errores
- [x] Navegar entre páginas (paginación) → ✅ Funciona sin errores
- [x] Ver historial de movimientos → ✅ Funciona sin errores

### Impacto
- **Severidad**: Crítica (múltiples bugs bloqueantes)
- **Usuarios afectados**: Todos los usuarios
- **Entornos afectados**: Desarrollo y Producción
- **Prioridad de merge**: Muy Alta

### Commits incluidos
- `8691322` - Fix: Corregir envío de campos talla y color en formulario
- `8e30d70` - Fix: Corregir error PDO con parámetros LIMIT y OFFSET
- `87edc86` - Fix: Corregir parámetros duplicados en búsqueda de productos

### Notas
Estos fixes son críticos y deben mergearse inmediatamente. Sin ellos, el sistema no puede:
- Guardar tallas y colores de productos
- Filtrar o paginar resultados
- Buscar productos por texto

Todos los cambios han sido probados en ambiente de desarrollo (dev.inventory.kyoshop.co).