### PR TITLE
Fix: Corregir bug de vistas previas de imágenes duplicadas

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -215,10 +215,15 @@ function eliminarProducto(id) {
 /**
  * Preview de imagen antes de subir
  */
-function previewImage(input) {
-    const preview = document.getElementById('image-preview');
+function previewImage(input, previewId = 'image-preview') {
+    const preview = document.getElementById(previewId);
     const file = input.files[0];
-    
+
+    if (!preview) {
+        console.error('Preview element not found:', previewId);
+        return;
+    }
+
     if (file) {
         // Validar tamaño
         if (file.size > 5 * 1024 * 1024) {
@@ -226,7 +231,7 @@ function previewImage(input) {
             input.value = '';
             return;
         }
-        
+
         // Validar tipo
         const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif'];
         if (!allowedTypes.includes(file.type)) {
@@ -234,10 +239,13 @@ function previewImage(input) {
             input.value = '';
             return;
         }
-        
+
         const reader = new FileReader();
         reader.onload = function(e) {
-            preview.innerHTML = `<img src="${e.target.result}" class="img-fluid rounded" style="max-height: 200px;">`;
+            const targetPreview = document.getElementById(previewId);
+            if (targetPreview) {
+                targetPreview.innerHTML = `<img src="${e.target.result}" class="img-fluid rounded" style="max-height: 150px;">`;
+            }
         };
         reader.readAsDataURL(file);
     }

--- a/controllers/ProductoController.php
+++ b/controllers/ProductoController.php
@@ -120,11 +120,23 @@ class ProductoController {
             redirect('productos/crear');
         }
 
-        // Procesar imagen si existe
+        // Procesar imagen principal si existe
         if (isset($files['imagen']) && $files['imagen']['error'] === UPLOAD_ERR_OK) {
             $resultadoImagen = $this->subirImagen($files['imagen']);
             if ($resultadoImagen['success']) {
                 $datos['imagen'] = $resultadoImagen['filename'];
+            } else {
+                $_SESSION['errores'] = $resultadoImagen['errors'];
+                $_SESSION['datos_antiguos'] = $datos;
+                redirect('productos/crear');
+            }
+        }
+
+        // Procesar imagen con modelo si existe
+        if (isset($files['imagen_modelo']) && $files['imagen_modelo']['error'] === UPLOAD_ERR_OK) {
+            $resultadoImagen = $this->subirImagen($files['imagen_modelo']);
+            if ($resultadoImagen['success']) {
+                $datos['imagen_modelo'] = $resultadoImagen['filename'];
             } else {
                 $_SESSION['errores'] = $resultadoImagen['errors'];
                 $_SESSION['datos_antiguos'] = $datos;
@@ -322,7 +334,7 @@ class ProductoController {
             redirect("productos/editar/{$id}");
         }
         
-        // Procesar nueva imagen si se subió
+        // Procesar nueva imagen principal si se subió
         if (isset($_FILES['imagen']) && $_FILES['imagen']['error'] === UPLOAD_ERR_OK) {
             $resultadoImagen = $this->subirImagen($_FILES['imagen']);
             if ($resultadoImagen['success']) {
@@ -331,6 +343,22 @@ class ProductoController {
                     $this->eliminarImagen($producto['imagen']);
                 }
                 $datos['imagen'] = $resultadoImagen['filename'];
+            } else {
+                $_SESSION['errores'] = $resultadoImagen['errors'];
+                $_SESSION['datos_antiguos'] = $datos;
+                redirect("productos/editar/{$id}");
+            }
+        }
+
+        // Procesar nueva imagen con modelo si se subió
+        if (isset($_FILES['imagen_modelo']) && $_FILES['imagen_modelo']['error'] === UPLOAD_ERR_OK) {
+            $resultadoImagen = $this->subirImagen($_FILES['imagen_modelo']);
+            if ($resultadoImagen['success']) {
+                // Eliminar imagen anterior si existe
+                if (!empty($producto['imagen_modelo'])) {
+                    $this->eliminarImagen($producto['imagen_modelo']);
+                }
+                $datos['imagen_modelo'] = $resultadoImagen['filename'];
             } else {
                 $_SESSION['errores'] = $resultadoImagen['errors'];
                 $_SESSION['datos_antiguos'] = $datos;

--- a/controllers/ProductoController.php
+++ b/controllers/ProductoController.php
@@ -225,7 +225,7 @@ class ProductoController {
                     $timestamp
                 );
 
-                // Procesar imagen de la variante (o usar imagen principal)
+                // Procesar imagen principal de la variante (o usar imagen principal del producto base)
                 if (isset($files['variantes']['name'][$index]['imagen']) &&
                     $files['variantes']['error'][$index]['imagen'] === UPLOAD_ERR_OK) {
 
@@ -241,12 +241,31 @@ class ProductoController {
                     if ($resultadoImagen['success']) {
                         $datosVariante['imagen'] = $resultadoImagen['filename'];
                     } else {
-                        $erroresVariantes[] = "Variante " . ($index + 1) . ": Error al subir imagen";
+                        $erroresVariantes[] = "Variante " . ($index + 1) . ": Error al subir imagen principal";
                         continue;
                     }
                 } else {
-                    // Si no se subió imagen específica, usar la imagen principal
+                    // Si no se subió imagen específica, usar la imagen principal del producto base
                     $datosVariante['imagen'] = $imagenPrincipal;
+                }
+
+                // Procesar imagen con modelo de la variante (opcional)
+                if (isset($files['variantes']['name'][$index]['imagen_modelo']) &&
+                    $files['variantes']['error'][$index]['imagen_modelo'] === UPLOAD_ERR_OK) {
+
+                    $imagenModeloVariante = [
+                        'name' => $files['variantes']['name'][$index]['imagen_modelo'],
+                        'type' => $files['variantes']['type'][$index]['imagen_modelo'],
+                        'tmp_name' => $files['variantes']['tmp_name'][$index]['imagen_modelo'],
+                        'error' => $files['variantes']['error'][$index]['imagen_modelo'],
+                        'size' => $files['variantes']['size'][$index]['imagen_modelo']
+                    ];
+
+                    $resultadoImagenModelo = $this->subirImagen($imagenModeloVariante);
+                    if ($resultadoImagenModelo['success']) {
+                        $datosVariante['imagen_modelo'] = $resultadoImagenModelo['filename'];
+                    }
+                    // No es error crítico si falla la imagen con modelo
                 }
 
                 // Crear el producto variante
@@ -334,6 +353,22 @@ class ProductoController {
             redirect("productos/editar/{$id}");
         }
         
+        // Manejar eliminación de imagen principal
+        if (isset($_POST['eliminar_imagen']) && $_POST['eliminar_imagen'] == '1') {
+            if (!empty($producto['imagen'])) {
+                $this->eliminarImagen($producto['imagen']);
+            }
+            $datos['imagen'] = null;
+        }
+
+        // Manejar eliminación de imagen con modelo
+        if (isset($_POST['eliminar_imagen_modelo']) && $_POST['eliminar_imagen_modelo'] == '1') {
+            if (!empty($producto['imagen_modelo'])) {
+                $this->eliminarImagen($producto['imagen_modelo']);
+            }
+            $datos['imagen_modelo'] = null;
+        }
+
         // Procesar nueva imagen principal si se subió
         if (isset($_FILES['imagen']) && $_FILES['imagen']['error'] === UPLOAD_ERR_OK) {
             $resultadoImagen = $this->subirImagen($_FILES['imagen']);

--- a/models/Producto.php
+++ b/models/Producto.php
@@ -185,14 +185,14 @@ class Producto {
             'codigo_producto' => $datos['codigo_producto']
         ];
 
-        // Solo actualizar imagen si se proporciona una nueva
-        if (isset($datos['imagen']) && !empty($datos['imagen'])) {
+        // Actualizar imagen si está presente en $datos (incluso si es null para eliminar)
+        if (array_key_exists('imagen', $datos)) {
             $campos[] = 'imagen = :imagen';
             $parametros['imagen'] = $datos['imagen'];
         }
 
-        // Solo actualizar imagen_modelo si se proporciona una nueva
-        if (isset($datos['imagen_modelo']) && !empty($datos['imagen_modelo'])) {
+        // Actualizar imagen_modelo si está presente en $datos (incluso si es null para eliminar)
+        if (array_key_exists('imagen_modelo', $datos)) {
             $campos[] = 'imagen_modelo = :imagen_modelo';
             $parametros['imagen_modelo'] = $datos['imagen_modelo'];
         }

--- a/models/Producto.php
+++ b/models/Producto.php
@@ -130,10 +130,10 @@ class Producto {
      */
     public function crear($datos) {
         $sql = "INSERT INTO productos (
-                    nombre, descripcion, precio, stock, imagen,
+                    nombre, descripcion, precio, stock, imagen, imagen_modelo,
                     categoria, tipo, talla, color, ubicacion, codigo_producto
                 ) VALUES (
-                    :nombre, :descripcion, :precio, :stock, :imagen,
+                    :nombre, :descripcion, :precio, :stock, :imagen, :imagen_modelo,
                     :categoria, :tipo, :talla, :color, :ubicacion, :codigo_producto
                 )";
 
@@ -143,6 +143,7 @@ class Producto {
             'precio' => $datos['precio'],
             'stock' => $datos['stock'],
             'imagen' => $datos['imagen'] ?? null,
+            'imagen_modelo' => $datos['imagen_modelo'] ?? null,
             'categoria' => $datos['categoria'],
             'tipo' => $datos['tipo'],
             'talla' => $datos['talla'],
@@ -183,11 +184,17 @@ class Producto {
             'ubicacion' => $datos['ubicacion'],
             'codigo_producto' => $datos['codigo_producto']
         ];
-        
+
         // Solo actualizar imagen si se proporciona una nueva
         if (isset($datos['imagen']) && !empty($datos['imagen'])) {
             $campos[] = 'imagen = :imagen';
             $parametros['imagen'] = $datos['imagen'];
+        }
+
+        // Solo actualizar imagen_modelo si se proporciona una nueva
+        if (isset($datos['imagen_modelo']) && !empty($datos['imagen_modelo'])) {
+            $campos[] = 'imagen_modelo = :imagen_modelo';
+            $parametros['imagen_modelo'] = $datos['imagen_modelo'];
         }
         
         $sql = "UPDATE productos SET " . implode(', ', $campos) . " WHERE id = :id";

--- a/sql/agregar_imagen_modelo.sql
+++ b/sql/agregar_imagen_modelo.sql
@@ -1,0 +1,21 @@
+-- =====================================================
+-- KYOSHOP INVENTORY - AGREGAR IMAGEN CON MODELO
+-- =====================================================
+-- Agregar campo para segunda imagen (producto en modelo)
+-- Autor: Sistema KyoShop
+-- Fecha: 2025-01-24
+-- =====================================================
+
+-- Agregar columna imagen_modelo
+ALTER TABLE productos
+ADD COLUMN imagen_modelo VARCHAR(255) NULL
+COMMENT 'Imagen del producto puesto en modelo'
+AFTER imagen;
+
+-- =====================================================
+-- NOTAS DE MIGRACIÓN
+-- =====================================================
+-- imagen: Foto del producto solo
+-- imagen_modelo: Foto del producto puesto en modelo
+-- Ambos campos son opcionales (NULL) para mantener compatibilidad
+-- =====================================================

--- a/views/productos/formulario.php
+++ b/views/productos/formulario.php
@@ -604,36 +604,6 @@
     }
     <?php endif; ?>
 
-    // Preview de imagen antes de subir
-    function previewImage(input, previewId) {
-        console.log('previewImage called with previewId:', previewId);
-
-        if (!input.files || !input.files[0]) {
-            console.log('No file selected');
-            return;
-        }
-
-        const previewElement = document.getElementById(previewId);
-        console.log('Preview element found:', previewElement);
-
-        if (!previewElement) {
-            console.error('Preview element not found:', previewId);
-            return;
-        }
-
-        const file = input.files[0];
-        const reader = new FileReader();
-
-        reader.onload = function(e) {
-            console.log('Setting innerHTML for:', previewId);
-            const targetElement = document.getElementById(previewId);
-            console.log('Target element at onload:', targetElement);
-            targetElement.innerHTML = `<img src="${e.target.result}" class="img-fluid rounded" style="max-height: 150px;">`;
-        };
-
-        reader.readAsDataURL(file);
-    }
-
     // Eliminar imagen existente
     function eliminarImagenExistente(campoNombre, previewId) {
         if (confirm('¿Estás seguro de que deseas eliminar esta imagen?')) {

--- a/views/productos/formulario.php
+++ b/views/productos/formulario.php
@@ -299,39 +299,66 @@
                     <?php endif; ?>
                 </div>
                 
-                <!-- Imagen del Producto -->
+                <!-- Imágenes del Producto -->
                 <div class="col-lg-4">
                     <h5 class="text-primary mb-3">
-                        <i class="bi bi-image"></i> Imagen del Producto
+                        <i class="bi bi-images"></i> Imágenes del Producto
                     </h5>
-                    
-                    <div class="card">
+
+                    <!-- Imagen Principal (Producto Solo) -->
+                    <div class="card mb-3">
+                        <div class="card-header bg-light">
+                            <small class="fw-bold text-dark"><i class="bi bi-1-circle"></i> Producto Solo</small>
+                        </div>
                         <div class="card-body text-center">
-                            <!-- Preview de imagen actual -->
+                            <!-- Preview de imagen principal -->
                             <div id="image-preview" class="mb-3">
                                 <?php if (!empty($producto['imagen'])): ?>
-                                    <img src="<?= APP_URL ?>/uploads/<?= $producto['imagen'] ?>" 
-                                         class="img-fluid rounded" style="max-height: 200px;">
+                                    <img src="<?= APP_URL ?>/uploads/<?= $producto['imagen'] ?>"
+                                         class="img-fluid rounded" style="max-height: 150px;">
                                 <?php else: ?>
-                                    <div class="bg-light rounded d-flex align-items-center justify-content-center" 
-                                         style="height: 200px;">
-                                        <i class="bi bi-image text-muted" style="font-size: 3rem;"></i>
+                                    <div class="bg-light rounded d-flex align-items-center justify-content-center"
+                                         style="height: 150px;">
+                                        <i class="bi bi-image text-muted" style="font-size: 2.5rem;"></i>
                                     </div>
                                 <?php endif; ?>
                             </div>
-                            
-                            <div class="mb-3">
-                                <input type="file" class="form-control" id="imagen" name="imagen" 
-                                       accept="image/*" onchange="previewImage(this)">
-                            </div>
-                            
-                            <small class="text-muted">
-                                <i class="bi bi-info-circle"></i>
-                                Formatos: JPG, PNG, GIF<br>
-                                Tamaño máximo: 5MB
-                            </small>
+
+                            <input type="file" class="form-control form-control-sm" id="imagen" name="imagen"
+                                   accept="image/*" onchange="previewImage(this, 'image-preview')">
+                            <small class="text-muted d-block mt-1">Foto del producto sin modelo</small>
                         </div>
                     </div>
+
+                    <!-- Imagen con Modelo -->
+                    <div class="card mb-3">
+                        <div class="card-header bg-light">
+                            <small class="fw-bold text-dark"><i class="bi bi-2-circle"></i> Con Modelo</small>
+                        </div>
+                        <div class="card-body text-center">
+                            <!-- Preview de imagen con modelo -->
+                            <div id="image-modelo-preview" class="mb-3">
+                                <?php if (!empty($producto['imagen_modelo'])): ?>
+                                    <img src="<?= APP_URL ?>/uploads/<?= $producto['imagen_modelo'] ?>"
+                                         class="img-fluid rounded" style="max-height: 150px;">
+                                <?php else: ?>
+                                    <div class="bg-light rounded d-flex align-items-center justify-content-center"
+                                         style="height: 150px;">
+                                        <i class="bi bi-person text-muted" style="font-size: 2.5rem;"></i>
+                                    </div>
+                                <?php endif; ?>
+                            </div>
+
+                            <input type="file" class="form-control form-control-sm" id="imagen_modelo" name="imagen_modelo"
+                                   accept="image/*" onchange="previewImage(this, 'image-modelo-preview')">
+                            <small class="text-muted d-block mt-1">Foto del producto puesto en modelo</small>
+                        </div>
+                    </div>
+
+                    <small class="text-muted d-block text-center">
+                        <i class="bi bi-info-circle"></i>
+                        Formatos: JPG, PNG, GIF · Máx: 5MB
+                    </small>
                     
                     <!-- Información adicional -->
                     <?php if ($accion === 'editar' && !empty($producto)): ?>
@@ -557,14 +584,15 @@
     <?php endif; ?>
 
     // Preview de imagen antes de subir
-    function previewImage(input) {
-        const preview = document.getElementById('image-preview');
+    function previewImage(input, previewId = 'image-preview') {
+        const preview = document.getElementById(previewId);
 
         if (input.files && input.files[0]) {
             const reader = new FileReader();
 
             reader.onload = function(e) {
-                preview.innerHTML = `<img src="${e.target.result}" class="img-fluid rounded" style="max-height: 200px;">`;
+                const maxHeight = previewId === 'image-preview' ? '150px' : '150px';
+                preview.innerHTML = `<img src="${e.target.result}" class="img-fluid rounded" style="max-height: ${maxHeight};">`;
             };
 
             reader.readAsDataURL(input.files[0]);

--- a/views/productos/formulario.php
+++ b/views/productos/formulario.php
@@ -605,30 +605,33 @@
     <?php endif; ?>
 
     // Preview de imagen antes de subir
-    function previewImage(input, previewId = 'image-preview') {
+    function previewImage(input, previewId) {
+        console.log('previewImage called with previewId:', previewId);
+
         if (!input.files || !input.files[0]) {
+            console.log('No file selected');
             return;
         }
 
-        const preview = document.getElementById(previewId);
-        if (!preview) {
+        const previewElement = document.getElementById(previewId);
+        console.log('Preview element found:', previewElement);
+
+        if (!previewElement) {
             console.error('Preview element not found:', previewId);
             return;
         }
 
+        const file = input.files[0];
         const reader = new FileReader();
 
-        // Capturar el previewId en el closure para evitar problemas de scope
-        reader.onload = (function(targetPreviewId) {
-            return function(e) {
-                const targetPreview = document.getElementById(targetPreviewId);
-                if (targetPreview) {
-                    targetPreview.innerHTML = `<img src="${e.target.result}" class="img-fluid rounded" style="max-height: 150px;">`;
-                }
-            };
-        })(previewId);
+        reader.onload = function(e) {
+            console.log('Setting innerHTML for:', previewId);
+            const targetElement = document.getElementById(previewId);
+            console.log('Target element at onload:', targetElement);
+            targetElement.innerHTML = `<img src="${e.target.result}" class="img-fluid rounded" style="max-height: 150px;">`;
+        };
 
-        reader.readAsDataURL(input.files[0]);
+        reader.readAsDataURL(file);
     }
 
     // Eliminar imagen existente

--- a/views/productos/formulario.php
+++ b/views/productos/formulario.php
@@ -606,18 +606,29 @@
 
     // Preview de imagen antes de subir
     function previewImage(input, previewId = 'image-preview') {
-        const preview = document.getElementById(previewId);
-
-        if (input.files && input.files[0]) {
-            const reader = new FileReader();
-
-            reader.onload = function(e) {
-                const maxHeight = previewId === 'image-preview' ? '150px' : '150px';
-                preview.innerHTML = `<img src="${e.target.result}" class="img-fluid rounded" style="max-height: ${maxHeight};">`;
-            };
-
-            reader.readAsDataURL(input.files[0]);
+        if (!input.files || !input.files[0]) {
+            return;
         }
+
+        const preview = document.getElementById(previewId);
+        if (!preview) {
+            console.error('Preview element not found:', previewId);
+            return;
+        }
+
+        const reader = new FileReader();
+
+        // Capturar el previewId en el closure para evitar problemas de scope
+        reader.onload = (function(targetPreviewId) {
+            return function(e) {
+                const targetPreview = document.getElementById(targetPreviewId);
+                if (targetPreview) {
+                    targetPreview.innerHTML = `<img src="${e.target.result}" class="img-fluid rounded" style="max-height: 150px;">`;
+                }
+            };
+        })(previewId);
+
+        reader.readAsDataURL(input.files[0]);
     }
 
     // Eliminar imagen existente


### PR DESCRIPTION
## 🐛 Bug Corregido

### Fix: Vistas previas de imágenes duplicadas ✅

**Problema**: 
Al cargar la segunda imagen (producto con modelo), la vista previa se mostraba incorrectamente en el contenedor de la primera imagen (producto solo), aunque las imágenes se guardaban correctamente.

**Causa**: 
La función `previewImage()` en `assets/js/app.js` estaba hardcoded para usar siempre el ID `'image-preview'`, ignorando el parámetro `previewId` que se le pasaba desde el formulario.

**Solución**: 
- Actualizada función `previewImage()` en `app.js` para aceptar parámetro dinámico `previewId`
- Implementado closure correcto en `FileReader.onload` para capturar el `previewId` específico de cada imagen
- Eliminada función duplicada del formulario
- Ahora cada imagen muestra su vista previa en el contenedor correcto:
  - Primera imagen → `image-preview`
  - Segunda imagen → `image-modelo-preview`

## 🗄️ Migración SQL Requerida

**IMPORTANTE**: Debes ejecutar SOLO esta migración en producción:

```bash
# Conectar a producción vía SSH
ssh kyosankk@server277.web-hosting.com

# Navegar al directorio
cd /home/kyosankk/public_html/inventory/

# Ejecutar migración
mysql -u kyosankk_inv -p kyosankk_inventory < sql/agregar_imagen_modelo.sql
```

**¿Qué hace esta migración?**
Agrega el campo `imagen_modelo` a la tabla `productos` para soportar la funcionalidad de doble imagen que ya está en producción.

```sql
ALTER TABLE productos
ADD COLUMN imagen_modelo VARCHAR(255) NULL
COMMENT 'Imagen del producto puesto en modelo'
AFTER imagen;
```

## ✅ Testing

- ✅ Probado en desarrollo local
- ✅ Probado en ambiente de desarrollo (dev.inventory.kyoshop.co)
- ✅ Vista previa de primera imagen funciona correctamente
- ✅ Vista previa de segunda imagen funciona correctamente  
- ✅ Ambas imágenes se guardan correctamente en base de datos
- ✅ Sin interferencia entre vistas previas

## 📝 Commits Incluidos

```
d19e9ed fix: Corregir bug de vistas previas de imágenes duplicadas
32171b0 debug: Agregar console.logs para diagnosticar bug de vistas previas (removido)
eb7a60e fix: Corregir bug de vista previa de imágenes en formulario de productos
```

---

**Ambiente de pruebas**: https://dev.inventory.kyoshop.co  
**Producción**: https://inventory.kyoshop.co