### PR TITLE
feat: Agregar variantes desde edición y mejoras de contraste

### DIFF
--- a/views/productos/formulario.php
+++ b/views/productos/formulario.php
@@ -106,22 +106,26 @@
                         </div>
                     </div>
 
-                    <?php if ($accion === 'crear'): ?>
-                        <!-- Opción de crear variantes (solo en creación) -->
-                        <div class="card border-info mb-3">
-                            <div class="card-body bg-info bg-opacity-10">
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" id="crear_variantes" name="crear_variantes" value="1">
-                                    <label class="form-check-label fw-bold text-dark" for="crear_variantes">
+                    <!-- Opción de crear variantes (disponible en creación y edición) -->
+                    <div class="card border-info mb-3">
+                        <div class="card-body bg-info bg-opacity-10">
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" id="crear_variantes" name="crear_variantes" value="1">
+                                <label class="form-check-label fw-bold text-dark" for="crear_variantes">
+                                    <?php if ($accion === 'crear'): ?>
                                         ¿Crear múltiples variantes?
                                         <small class="d-block fw-normal text-dark">Activa esta opción si tienes el mismo producto en diferentes colores y/o tallas</small>
-                                    </label>
-                                </div>
+                                    <?php else: ?>
+                                        ¿Agregar nuevas variantes?
+                                        <small class="d-block fw-normal text-dark">Activa esta opción para agregar variantes adicionales a este producto</small>
+                                    <?php endif; ?>
+                                </label>
                             </div>
                         </div>
+                    </div>
 
-                        <!-- Campos simples (se ocultan si selecciona variantes) -->
-                        <div id="campos-simples">
+                    <!-- Campos simples (se ocultan si selecciona variantes) -->
+                    <div id="campos-simples" <?php echo ($accion === 'crear') ? '' : 'style="display: block;"'; ?>>
                             <div class="row">
                                 <div class="col-md-6 mb-3">
                                     <label for="color" class="form-label">Color</label>
@@ -205,7 +209,7 @@
                         <!-- Área de variantes (se muestra si selecciona variantes) -->
                         <div id="area-variantes" style="display: none;">
                             <h6 class="text-primary mb-3">
-                                <i class="bi bi-grid"></i> Variantes del Producto
+                                <i class="bi bi-grid"></i> <?php echo $accion === 'crear' ? 'Variantes del Producto' : 'Nuevas Variantes'; ?>
                             </h6>
 
                             <div id="variantes-container">
@@ -216,6 +220,9 @@
                                 <i class="bi bi-plus-circle"></i> Agregar Variante
                             </button>
                         </div>
+
+                    <?php if ($accion === 'editar'): ?>
+                        <!-- En modo edición, también mostrar campos normales (ocultos cuando se activen variantes) -->
                     <?php else: ?>
                         <!-- En modo edición, campos normales -->
                         <div class="row">
@@ -430,8 +437,7 @@
 </div>
 
 <script>
-    <?php if ($accion === 'crear'): ?>
-    // Gestión de variantes
+    // Gestión de variantes (disponible en crear y editar)
     let contadorVariantes = 0;
     const checkboxVariantes = document.getElementById('crear_variantes');
     const camposSimples = document.getElementById('campos-simples');
@@ -444,8 +450,10 @@
         if (this.checked) {
             camposSimples.style.display = 'none';
             areaVariantes.style.display = 'block';
+            <?php if ($accion === 'crear'): ?>
             stockInput.disabled = true;
             stockInput.value = 0;
+            <?php endif; ?>
             // NO deshabilitar imagen principal - se usará como default para variantes
 
             // Agregar primera variante automáticamente
@@ -455,7 +463,9 @@
         } else {
             camposSimples.style.display = 'block';
             areaVariantes.style.display = 'none';
+            <?php if ($accion === 'crear'): ?>
             stockInput.disabled = false;
+            <?php endif; ?>
 
             // Limpiar variantes
             document.getElementById('variantes-container').innerHTML = '';
@@ -614,7 +624,6 @@
             reader.readAsDataURL(input.files[0]);
         }
     }
-    <?php endif; ?>
 
     // Eliminar imagen existente
     function eliminarImagenExistente(campoNombre, previewId) {

--- a/views/productos/index.php
+++ b/views/productos/index.php
@@ -654,4 +654,12 @@ document.addEventListener('DOMContentLoaded', function() {
 #variantesContainer .border {
     border-color: #667eea !important;
 }
+
+#variantesContainer label {
+    color: #212529 !important;
+}
+
+#variantesContainer small {
+    color: #6c757d !important;
+}
 </style>

--- a/views/productos/index.php
+++ b/views/productos/index.php
@@ -634,10 +634,21 @@ document.addEventListener('DOMContentLoaded', function() {
     font-weight: bold;
 }
 
+.variante-btn.active strong {
+    color: white;
+    font-weight: 700;
+}
+
+.variante-btn.active small {
+    color: rgba(255, 255, 255, 0.95);
+    font-weight: 600;
+}
+
 .variante-btn small {
     display: block;
-    font-size: 0.75rem;
+    font-size: 0.8rem;
     margin-top: 2px;
+    font-weight: 500;
 }
 
 #variantesContainer .border {


### PR DESCRIPTION
## Resumen

Se agrega la funcionalidad para crear variantes adicionales desde el modo edición de productos, además de múltiples mejoras visuales y de usabilidad en el formulario de productos y selector de variantes.

## Cambios principales

### ✨ Nueva funcionalidad: Agregar variantes desde edición
- Agregado checkbox "¿Agregar nuevas variantes?" en formulario de edición
- Creado método `agregarVariantesDesdeEdicion()` en ProductoController
- JavaScript actualizado para soportar variantes en ambos modos (crear/editar)
- Las variantes heredan datos del producto base (nombre, precio, categoría, ubicación, imagen)
- Se registran movimientos en historial con motivo específico
- **El stock del producto original NO se altera**
- Las variantes se crean como productos nuevos independientes

### 🎨 Mejoras de UX/UI

**Formulario de productos:**
- Reordenado: checkbox de variantes ahora aparece después de campos talla/color
- Eliminados campos duplicados de color/talla en modo crear
- Mejorado contraste del checkbox con color azul vibrante (#667eea)
- Agregado fondo con gradiente sutil para destacar sección de variantes

**Selector de variantes (modal vista previa):**
- Incrementado font-weight de texto activo en botones (700)
- Mejorado visibilidad del stock en botones activos (font-weight: 600)
- Aumentado tamaño de fuente del stock (0.8rem)
- Forzado color oscuro en label "Selecciona una variante" (#212529)
- Asegurado color blanco sólido en texto cuando el botón está activo

## Archivos modificados

- `controllers/ProductoController.php` (+133 líneas)
- `views/productos/formulario.php` (+41 líneas, mejor UX)
- `views/productos/index.php` (+20 líneas, mejor contraste)

## Protecciones implementadas

✅ Stock del producto original protegido
✅ Base de datos existente no se altera
✅ Solo se crean productos NUEVOS (variantes)
✅ Validaciones de campos obligatorios
✅ Manejo de errores en subida de imágenes

## Commits incluidos

1. `feat:` Permitir agregar variantes desde el modo edición de productos
2. `fix:` Mejorar contraste de texto en botones de variantes
3. `fix:` Forzar color oscuro en label de selector de variantes
4. `fix:` Eliminar campos duplicados de color/talla en modo crear
5. `refactor:` Mover checkbox de variantes después de campos talla/color
6. `fix:` Mejorar contraste en checkbox de crear variantes

## Pruebas

- [x] Funcionalidad probada en desarrollo local
- [x] Variantes se crean correctamente desde edición
- [x] Contraste mejorado en todos los componentes
- [x] Formulario sin campos duplicados
- [x] Mejor flujo visual del formulario
- [ ] Pendiente pruebas en dev.inventory.kyoshop.co

## Deployment

Este PR desplegará automáticamente a producción (`inventory.kyoshop.co`) al hacer merge a `main`.