### PR TITLE
fix: Eliminar límite de 50 productos en búsqueda de ventas

### DIFF
--- a/controllers/VentaController.php
+++ b/controllers/VentaController.php
@@ -236,22 +236,19 @@ class VentaController {
 
         $termino = $_POST['termino'] ?? '';
 
-        // Si no hay término de búsqueda, devolver todos los productos con stock
-        if (empty($termino)) {
-            $productos = $this->producto->obtenerTodos(1, 100, ['stock_minimo' => 1]);
-            $this->enviarJSON(['productos' => $productos]);
-            return;
+        // Preparar filtros para obtener productos con stock
+        $filtros = ['stock_minimo' => 1];
+
+        // Si hay término de búsqueda, agregarlo a los filtros
+        if (!empty($termino)) {
+            $filtros['busqueda'] = $termino;
         }
 
-        // Buscar productos que tengan stock disponible
-        $productos = $this->producto->buscar($termino, 50);
+        // Obtener todos los productos que coincidan (sin límite de paginación)
+        // Usar un límite alto para asegurar que se devuelvan todos los productos
+        $productos = $this->producto->obtenerTodos(1, 10000, $filtros);
 
-        // Filtrar solo productos con stock > 0
-        $productosConStock = array_filter($productos, function($producto) {
-            return $producto['stock'] > 0;
-        });
-
-        $this->enviarJSON(['productos' => array_values($productosConStock)]);
+        $this->enviarJSON(['productos' => $productos]);
     }
 
     /**


### PR DESCRIPTION
## Problema
Al buscar productos en el formulario de registro de ventas, solo aparecían los primeros 50 resultados debido a un límite hardcodeado en el método `buscarProducto()`.

**Ejemplo:** Al buscar "jean embaraza" solo aparecía 1 producto cuando existían múltiples variantes en el inventario.

## Solución
- Cambiar de usar `buscar()` (límite 50) a `obtenerTodos()` con filtro de búsqueda
- Aumentar límite a 10,000 productos para asegurar que se muestren todos los resultados
- Mantener filtro `stock_minimo = 1` para mostrar solo productos con stock disponible

## Cambios
- **Archivo modificado:** `controllers/VentaController.php`
- **Método:** `buscarProducto()` (líneas 231-252)
- **Impacto:** Mejora la experiencia al registrar ventas mostrando todos los productos disponibles

## Testing
✅ Probado en ambiente de desarrollo
✅ Solo modifica el endpoint AJAX de búsqueda de productos en ventas
✅ No afecta otras funcionalidades del sistema

## Tipo de cambio
- [x] Bug fix (cambio que corrige un problema)
- [ ] Nueva funcionalidad
- [ ] Breaking change
- [ ] Refactoring

## Checklist
- [x] El código sigue las convenciones del proyecto
- [x] Los cambios no rompen funcionalidad existente
- [x] Solo se modifica un archivo (VentaController.php)
- [x] El cambio es seguro para producción