### PR TITLE
fix: Corregir error de token CSRF al eliminar productos en ventas

### DIFF
--- a/views/ventas/formulario.php
+++ b/views/ventas/formulario.php
@@ -675,7 +675,7 @@ function actualizarListaProductosAgregados() {
                             <strong class="d-block">${escapeHtml(producto.nombre)}</strong>
                             <small class="text-muted">${escapeHtml(producto.codigo)}</small>
                         </div>
-                        <button type="button" class="btn btn-sm btn-danger ms-2" onclick="eliminarProducto(${index})" title="Eliminar">
+                        <button type="button" class="btn btn-sm btn-danger ms-2" onclick="eliminarProductoDelCarrito(${index})" title="Eliminar">
                             <i class="bi bi-trash"></i>
                         </button>
                     </div>
@@ -734,16 +734,13 @@ function actualizarCantidad(index, cantidad) {
     actualizarListaProductosAgregados();
 }
 
-function eliminarProducto(index) {
+function eliminarProductoDelCarrito(index) {
     if (confirm('¿Está seguro de eliminar este producto de la venta?')) {
         productosAgregados.splice(index, 1);
         actualizarListaProductosAgregados();
 
         // Refrescar la lista de productos para quitar el badge "Agregado"
-        const termino = document.getElementById('busquedaProducto').value.trim();
-        if (termino.length > 0) {
-            document.getElementById('busquedaProducto').dispatchEvent(new Event('input'));
-        }
+        aplicarFiltrosYOrden();
     }
 }
 


### PR DESCRIPTION
## Descripción del cambio

Soluciona el bug que causaba un error de "Token de seguridad inválido" al intentar eliminar productos agregados en el formulario de creación de ventas.

## Problema identificado

Existía un **conflicto de nombres de funciones** entre:
- Función global `eliminarProducto(id)` en `assets/js/app.js` (diseñada para eliminar productos de la base de datos)
- Función local `eliminarProducto(index)` en el formulario de ventas (diseñada para quitar productos del carrito temporal)

Cuando el usuario hacía clic en eliminar, JavaScript ejecutaba la función global que:
1. Intentaba crear un formulario POST
2. Buscaba un token CSRF en un meta tag inexistente
3. Fallaba con el error "Token de seguridad inválido"

## Solución implementada

- ✅ Renombrar función local a `eliminarProductoDelCarrito(index)`
- ✅ Actualizar llamada en el botón de eliminar
- ✅ Mejorar el refrescado de la lista de productos usando `aplicarFiltrosYOrden()`

## Archivos modificados

- `views/ventas/formulario.php`

## Tipo de cambio

- [x] Bug fix (cambio que corrige un problema)
- [ ] Nueva funcionalidad
- [ ] Breaking change
- [ ] Mejora de rendimiento

## Testing

- [x] Probado localmente
- [ ] Probado en dev.inventory.kyoshop.co (pendiente)
- [ ] Requiere pruebas adicionales

## Checklist

- [x] El código sigue las convenciones del proyecto
- [x] Los cambios están documentados en el commit
- [x] No introduce nuevos warnings o errores
- [x] Los cambios son específicos y enfocados en el problema